### PR TITLE
fix(trezor-transport): add react-native override for webusb transport

### DIFF
--- a/packages/trezor-transport/package.json
+++ b/packages/trezor-transport/package.json
@@ -22,6 +22,7 @@
         "./src/transports/webusb": "./src/transports/webusb.browser.ts"
     },
     "react-native": {
+        "./lib/transports/webusb": "./lib/transports/webusb.js",
         "./src/transports/udp": "./src/transports/udp.native.ts"
     },
     "publishConfig": {
@@ -32,6 +33,7 @@
             "./lib/transports/webusb": "./lib/transports/webusb.browser.js"
         },
         "react-native": {
+            "./lib/transports/webusb": "./lib/transports/webusb.js",
             "./lib/transports/udp": "./lib/transports/udp.native.js"
         }
     },


### PR DESCRIPTION
towards:
- https://github.com/ExodusMovement/exodus-mobile/issues/38923

## Description

Metro falls through from react-native to browser field when a path is missing, causing webusb.browser.js (which uses window.location and navigator.usb) to be loaded in React Native instead of the safe no-op stub


